### PR TITLE
feat(web): 에디토리얼 기록 저널 UI 시안 추가

### DIFF
--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/App.css",
+    "baseColor": "stone",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -32,3 +32,181 @@
 .shake-animation {
   animation: shake 600ms ease-in-out;
 }
+
+:root {
+  color-scheme: light;
+  font-synthesis: none;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: #e9dfd0;
+}
+
+::selection {
+  background: rgba(166, 79, 56, 0.2);
+  color: #2e2722;
+}
+
+.editorial-shell {
+  position: relative;
+  isolation: isolate;
+  font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif;
+  background-color: #e9dfd0;
+  background-image:
+    radial-gradient(
+      circle at 14% 16%,
+      rgba(255, 251, 243, 0.8),
+      transparent 32%
+    ),
+    linear-gradient(125deg, rgba(112, 88, 62, 0.035), transparent 36%),
+    radial-gradient(rgba(81, 60, 42, 0.09) 0.45px, transparent 0.55px);
+  background-size:
+    auto,
+    auto,
+    5px 5px;
+}
+
+.editorial-shell .font-serif,
+.editorial-command-palette .font-serif {
+  font-family:
+    'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Palatino,
+    Baskerville, Georgia, serif;
+}
+
+.journal-page::before {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: '';
+  background-image:
+    linear-gradient(90deg, rgba(166, 79, 56, 0.07) 1px, transparent 1px),
+    radial-gradient(rgba(93, 69, 47, 0.09) 0.4px, transparent 0.55px);
+  background-position:
+    28px 0,
+    0 0;
+  background-size:
+    calc(100% - 56px) 100%,
+    6px 6px;
+  opacity: 0.28;
+}
+
+.journal-page::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 18px;
+  width: 1px;
+  content: '';
+  background: rgba(166, 79, 56, 0.28);
+}
+
+.journal-raw-log {
+  caret-color: #a64f38;
+  background-color: rgba(255, 251, 243, 0.72);
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 31px,
+      rgba(133, 112, 88, 0.2) 31px,
+      rgba(133, 112, 88, 0.2) 32px
+    ),
+    radial-gradient(rgba(92, 70, 49, 0.08) 0.45px, transparent 0.55px);
+  background-position:
+    0 20px,
+    0 0;
+  background-size:
+    100% 32px,
+    6px 6px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+    inset 0 0 35px rgba(92, 70, 49, 0.025);
+}
+
+.editorial-kbd {
+  display: inline-flex;
+  min-width: 1.25rem;
+  height: 1.2rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #cabba8;
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  padding: 0 0.3rem;
+  background: rgba(255, 251, 243, 0.68);
+  color: #675c51;
+  font-family: inherit;
+  font-size: 9px;
+  line-height: 1;
+}
+
+.editorial-actions .btn {
+  min-height: 2.25rem;
+  height: 2.25rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: #665b50;
+  padding: 0 0.65rem;
+}
+
+.editorial-actions .btn-circle {
+  width: 2.25rem;
+  padding: 0;
+}
+
+.editorial-actions .btn:hover {
+  background: #ded1c0;
+  color: #2f2823;
+}
+
+.editorial-actions .dropdown-content {
+  border-color: #c9baa7;
+  background: #fbf4e8;
+  color: #3e352e;
+}
+
+.editorial-shell .modal-box {
+  border: 1px solid #c9baa7;
+  border-radius: 4px;
+  background: #fbf4e8;
+  color: #332b25;
+  box-shadow: 0 28px 80px rgba(55, 39, 25, 0.24);
+}
+
+.editorial-shell .modal-box .input {
+  border-color: #c9baa7;
+  background: #fffaf1;
+}
+
+.editorial-analysis-card {
+  animation: editorial-reveal 520ms ease-out both;
+}
+
+.editorial-analysis-card:nth-of-type(3) {
+  animation-delay: 90ms;
+}
+
+@keyframes editorial-reveal {
+  from {
+    transform: translateY(5px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editorial-analysis-card {
+    animation: none;
+  }
+}

--- a/apps/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette/CommandPalette.tsx
@@ -2,6 +2,9 @@ import clsx from 'clsx';
 import { MinusCircle, PlusCircle, Search } from 'lucide-react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
+import { Card } from '../ui/card';
+import { Input } from '../ui/input';
+
 export interface Command {
   id: string;
   label: string;
@@ -38,7 +41,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
         {
           id: 'dynamic-add-production',
           label: content ? `생산 기록 추가: ${content}` : '생산 기록 추가',
-          description: '입력한 내용으 생산 기록을 추가합니다',
+          description: '입력한 내용으로 생산 기록을 추가합니다',
           icon: <PlusCircle size={18} />,
           action: () => {
             import('../../utils/commandEvents').then((module) => {
@@ -149,29 +152,35 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="modal modal-open">
-      {/* 배경 클릭 시 닫기 */}
-      <div className="modal-backdrop" onClick={onClose} />
+    <div className="editorial-command-palette fixed inset-0 z-50 flex items-start justify-center px-6 pt-[14vh]">
+      <button
+        type="button"
+        className="absolute inset-0 cursor-default bg-[#241d18]/45 backdrop-blur-[2px]"
+        onClick={onClose}
+        aria-label="명령 팔레트 닫기"
+      />
 
-      <div className="modal-box relative max-w-lg overflow-hidden p-0">
-        {/* 검색 입력 */}
-        <div className="flex items-center gap-3 border-b border-base-300 px-4 py-3">
-          <Search className="h-5 w-5 text-base-content/50" />
-          <input
+      <Card
+        role="dialog"
+        aria-modal="true"
+        aria-label="명령 팔레트"
+        className="relative w-full max-w-xl overflow-hidden rounded-[4px] border-[#bbaa96] bg-[#fbf4e8] shadow-[0_30px_100px_rgba(35,25,18,0.38)]"
+      >
+        <div className="flex items-center gap-3 border-b border-[#cfc1ae] px-5 py-4">
+          <Search className="h-4 w-4 text-[#a64f38]" />
+          <Input
             ref={inputRef}
-            type="text"
-            className="flex-1 bg-transparent text-base outline-none placeholder:text-base-content/40"
-            placeholder="명령어 검색..."
+            className="h-auto flex-1 border-0 bg-transparent px-0 font-serif text-lg focus:border-0 focus:ring-0"
+            placeholder="무엇을 기록할까요?"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
-          <kbd className="kbd kbd-sm">ESC</kbd>
+          <kbd className="editorial-kbd">ESC</kbd>
         </div>
 
-        {/* 커맨드 목록 */}
-        <div ref={listRef} className="max-h-80 overflow-y-auto py-2">
+        <div ref={listRef} className="max-h-80 overflow-y-auto py-2.5">
           {filteredCommands.length === 0 ? (
-            <div className="px-4 py-8 text-center text-base-content/50">
+            <div className="px-5 py-9 text-center font-serif italic text-[#8a7d70]">
               검색 결과가 없습니다
             </div>
           ) : (
@@ -180,10 +189,10 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
                 key={command.id}
                 type="button"
                 className={clsx(
-                  'flex w-full items-center gap-3 px-4 py-3 text-left transition-colors',
+                  'flex w-full items-center gap-3 border-l-2 px-5 py-3 text-left transition-colors',
                   index === selectedIndex
-                    ? 'bg-primary/10 text-primary'
-                    : 'hover:bg-base-200',
+                    ? 'border-[#a64f38] bg-[#efe2d2] text-[#8f412e]'
+                    : 'border-transparent text-[#41372f] hover:bg-[#f4eadd]',
                 )}
                 onClick={() => {
                   command.action();
@@ -192,38 +201,43 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
                 onMouseEnter={() => setSelectedIndex(index)}
               >
                 {command.icon && (
-                  <span className="flex-shrink-0">{command.icon}</span>
+                  <span className="flex-shrink-0 text-[#a64f38]">
+                    {command.icon}
+                  </span>
                 )}
                 <div className="min-w-0 flex-1">
-                  <div className="font-medium">{command.label}</div>
+                  <div className="font-serif font-semibold">
+                    {command.label}
+                  </div>
                   {command.description && (
-                    <div className="truncate text-sm text-base-content/60">
+                    <div className="mt-0.5 truncate text-[11px] text-[#85786b]">
                       {command.description}
                     </div>
                   )}
                 </div>
-                {index === selectedIndex && <kbd className="kbd kbd-sm">↵</kbd>}
+                {index === selectedIndex && (
+                  <kbd className="editorial-kbd">↵</kbd>
+                )}
               </button>
             ))
           )}
         </div>
 
-        {/* 도움말 */}
-        <div className="flex items-center justify-between border-t border-base-300 bg-base-200/50 px-4 py-2 text-xs text-base-content/60">
+        <div className="flex items-center justify-between border-t border-[#cfc1ae] bg-[#f1e6d8] px-5 py-2.5 text-[10px] text-[#776b5f]">
           <div className="flex items-center gap-4">
             <span>
-              <kbd className="kbd kbd-xs">↑</kbd>
-              <kbd className="kbd kbd-xs">↓</kbd> 이동
+              <kbd className="editorial-kbd">↑</kbd>
+              <kbd className="editorial-kbd">↓</kbd> 이동
             </span>
             <span>
-              <kbd className="kbd kbd-xs">↵</kbd> 실행
+              <kbd className="editorial-kbd">↵</kbd> 실행
             </span>
           </div>
           <span>
-            <kbd className="kbd kbd-xs">ESC</kbd> 닫기
+            <kbd className="editorial-kbd">ESC</kbd> 닫기
           </span>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/apps/web/src/components/charts/AvailableRestTimeChart/chart.tsx
+++ b/apps/web/src/components/charts/AvailableRestTimeChart/chart.tsx
@@ -2,6 +2,7 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -32,26 +33,34 @@ export const AvailableRestTimeChart = ({
   const gradientId = 'availableRestTimeSplitColor';
 
   return (
-    <ResponsiveContainer className="min-h-0">
+    <ResponsiveContainer width="100%" height="100%">
       <AreaChart
         data={data}
         margin={{
-          top: 30,
-          right: 30,
-          left: 0,
-          bottom: 30,
+          top: 20,
+          right: 8,
+          left: -22,
+          bottom: 2,
         }}
       >
-        <CartesianGrid strokeDasharray="3 3" />
+        <CartesianGrid
+          vertical={false}
+          stroke="#d8ccbc"
+          strokeDasharray="2 5"
+        />
         <XAxis
           dataKey="offset"
           type="number"
-          tick={{ fontSize: 16 }}
+          tick={{ fontSize: 10, fill: '#817568' }}
+          tickLine={false}
+          axisLine={{ stroke: '#bfb09d' }}
           tickFormatter={minutesToTimeString}
           domain={[minXAxisDomain, maxXAxisDomain]}
         />
         <YAxis
-          tick={{ fontSize: 16 }}
+          tick={{ fontSize: 10, fill: '#817568' }}
+          tickLine={false}
+          axisLine={false}
           domain={yAxisConfig.domain}
           ticks={yAxisConfig.ticks}
           tickFormatter={(value) => `${value}`}
@@ -59,18 +68,36 @@ export const AvailableRestTimeChart = ({
         <Tooltip
           labelFormatter={minutesToTimeString}
           formatter={(value: number | string) => [`${value}분`, '초과 휴식']}
+          cursor={{ stroke: '#a64f38', strokeDasharray: '2 4' }}
+          contentStyle={{
+            background: '#fbf4e8',
+            border: '1px solid #c9baa7',
+            borderRadius: 3,
+            color: '#3b332c',
+            fontSize: 11,
+          }}
         />
+        <ReferenceLine y={0} stroke="#9e8d7a" strokeWidth={1} />
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-            <stop offset={gradientOffset} stopColor="red" stopOpacity={1} />
-            <stop offset={gradientOffset} stopColor="green" stopOpacity={1} />
+            <stop
+              offset={gradientOffset}
+              stopColor="#a64f38"
+              stopOpacity={0.22}
+            />
+            <stop
+              offset={gradientOffset}
+              stopColor="#66715d"
+              stopOpacity={0.2}
+            />
           </linearGradient>
         </defs>
         <Area
           type="monotone"
           dataKey="need"
           unit="min"
-          stroke="#000"
+          stroke="#8f4937"
+          strokeWidth={1.8}
           fill={`url(#${gradientId})`}
         />
         {getPoints(data)}

--- a/apps/web/src/components/charts/AvailableRestTimeChart/points.tsx
+++ b/apps/web/src/components/charts/AvailableRestTimeChart/points.tsx
@@ -11,46 +11,46 @@ export const getPoints = (data: ChartDataPoint[]) => {
   const points: ReactElement[] = [];
 
   if (highPoint) {
-    const color = highPoint.need >= 0 ? 'red' : 'green';
+    const color = highPoint.need >= 0 ? '#a64f38' : '#66715d';
     points.push(
       <ReferenceDot
         key="high"
         x={highPoint.offset}
         y={highPoint.need}
-        r={5}
+        r={3}
         fill={color}
-        stroke="white"
-        strokeWidth={2}
+        stroke="#fbf4e8"
+        strokeWidth={1.5}
       >
         <Label
           value={formatMinutesWithSign(highPoint.need)}
           position="top"
           fill={color}
-          fontSize={14}
-          fontWeight="bold"
+          fontSize={10}
+          fontWeight={600}
         />
       </ReferenceDot>,
     );
   }
 
   if (lowPoint) {
-    const color = lowPoint.need >= 0 ? 'red' : 'green';
+    const color = lowPoint.need >= 0 ? '#a64f38' : '#66715d';
     points.push(
       <ReferenceDot
         key="low"
         x={lowPoint.offset}
         y={lowPoint.need}
-        r={5}
+        r={3}
         fill={color}
-        stroke="white"
-        strokeWidth={2}
+        stroke="#fbf4e8"
+        strokeWidth={1.5}
       >
         <Label
           value={formatMinutesWithSign(lowPoint.need)}
           position="bottom"
           fill={color}
-          fontSize={14}
-          fontWeight="bold"
+          fontSize={10}
+          fontWeight={600}
         />
       </ReferenceDot>,
     );
@@ -62,17 +62,17 @@ export const getPoints = (data: ChartDataPoint[]) => {
         key="current"
         x={currentPointConfig.point.offset}
         y={currentPointConfig.point.need}
-        r={6}
+        r={3.5}
         fill={currentPointConfig.color}
-        stroke="white"
-        strokeWidth={2}
+        stroke="#fbf4e8"
+        strokeWidth={1.5}
       >
         <Label
           value={formatMinutesWithSign(currentPointConfig.point.need)}
           position={currentPointConfig.position}
           fill={currentPointConfig.color}
-          fontSize={14}
-          fontWeight="bold"
+          fontSize={10}
+          fontWeight={600}
         />
       </ReferenceDot>,
     );
@@ -117,7 +117,7 @@ function isNearPoint(
 type CurrentPointConfig = {
   point: ChartDataPoint | null;
   shouldShow: boolean;
-  color: 'red' | 'green';
+  color: '#a64f38' | '#66715d';
   position: 'top' | 'bottom';
 };
 
@@ -131,14 +131,14 @@ function getCurrentPointConfig(
     return {
       point: null,
       shouldShow: false,
-      color: 'red',
+      color: '#a64f38',
       position: 'top',
     };
   }
 
   const shouldShow =
     !isNearPoint(currPoint, highPoint) && !isNearPoint(currPoint, lowPoint);
-  const color = currPoint.need >= 0 ? 'red' : 'green';
+  const color = currPoint.need >= 0 ? '#a64f38' : '#66715d';
   const position = currPoint.need >= 0 ? 'top' : 'bottom';
 
   return { point: currPoint, shouldShow, color, position };

--- a/apps/web/src/components/charts/DayRatioBar.tsx
+++ b/apps/web/src/components/charts/DayRatioBar.tsx
@@ -8,7 +8,7 @@ export const DayRatioBar = ({ logs }: { logs: Log[] }) => {
 
   if (isEmpty || totalDuration <= 0) {
     return (
-      <div className="flex h-3 w-full min-w-0 overflow-hidden rounded-full bg-gray-200" />
+      <div className="flex h-1.5 w-full min-w-0 overflow-hidden rounded-full bg-[#ddd1c1]" />
     );
   }
 
@@ -36,14 +36,14 @@ export const DayRatioBar = ({ logs }: { logs: Log[] }) => {
 
   return (
     <div
-      className="isolate flex h-3 w-full min-w-0 transform-gpu flex-nowrap overflow-hidden rounded-full bg-gray-100"
+      className="isolate flex h-1.5 w-full min-w-0 transform-gpu flex-nowrap overflow-hidden rounded-full bg-[#ddd1c1]"
       style={{ WebkitMaskImage: '-webkit-radial-gradient(white, black)' }}
     >
       {blocks.map((block, idx) => (
         <div
           key={idx}
           className={`transition-all duration-500 ease-in-out ${
-            block.type === 'productive' ? 'bg-green-500' : 'bg-red-500'
+            block.type === 'productive' ? 'bg-[#66715d]' : 'bg-[#a64f38]'
           }`}
           style={{ width: `${(block.duration / totalDuration) * 100}%` }}
           title={`${block.type === 'productive' ? '생산' : '소비'}: ${block.duration}분`}

--- a/apps/web/src/components/charts/ProductivePaceChart.tsx
+++ b/apps/web/src/components/charts/ProductivePaceChart.tsx
@@ -26,54 +26,97 @@ export const ProductivePaceChart = ({
   targetPace,
 }: ProductivePaceChartProps) => {
   return (
-    <ResponsiveContainer className="min-h-0">
+    <ResponsiveContainer width="100%" height="100%">
       <AreaChart
         data={data}
         margin={{
-          top: 10,
-          right: 30,
-          left: 0,
-          bottom: 0,
+          top: 16,
+          right: 8,
+          left: -22,
+          bottom: 2,
         }}
       >
-        <CartesianGrid strokeDasharray="3 3" />
+        <CartesianGrid
+          vertical={false}
+          stroke="#d8ccbc"
+          strokeDasharray="2 5"
+        />
         <XAxis
           dataKey="offset"
           type="number"
-          tick={{ fontSize: 16 }}
+          tick={{ fontSize: 10, fill: '#817568' }}
+          tickLine={false}
+          axisLine={{ stroke: '#bfb09d' }}
           tickFormatter={minutesToTimeString}
           domain={[8 * 60, 27 * 60]}
         />
         <YAxis
           domain={[0, 60]}
           allowDataOverflow={true}
-          tick={{ fontSize: 16 }}
+          tick={{ fontSize: 10, fill: '#817568' }}
+          tickLine={false}
+          axisLine={false}
         />
-        <Tooltip labelFormatter={minutesToTimeString} />
-        <ReferenceLine
-          y={targetPace}
-          stroke="red"
-          label={{ value: `목표: ${targetPace}min/h`, fontSize: 16 }}
-        />
-        <ReferenceLine
-          y={totalAvg}
-          stroke="blue"
-          label={{
-            value: `[미지원] 전체 평균(${totalAvg}min/h)`,
-            fontSize: 16,
+        <Tooltip
+          labelFormatter={minutesToTimeString}
+          formatter={(value: number | string) => [
+            `${value}분/시`,
+            '생산 페이스',
+          ]}
+          cursor={{ stroke: '#66715d', strokeDasharray: '2 4' }}
+          contentStyle={{
+            background: '#fbf4e8',
+            border: '1px solid #c9baa7',
+            borderRadius: 3,
+            color: '#3b332c',
+            fontSize: 11,
           }}
         />
         <ReferenceLine
-          y={todayAvg}
-          stroke="green"
-          label={{ value: `오늘 평균(${todayAvg}min/h)`, fontSize: 16 }}
+          y={targetPace}
+          stroke="#a64f38"
+          strokeDasharray="4 4"
+          label={{
+            value: `목표 ${targetPace}`,
+            position: 'insideTopRight',
+            fontSize: 9,
+            fill: '#8f4937',
+          }}
         />
+        {totalAvg > 0 && (
+          <ReferenceLine
+            y={totalAvg}
+            stroke="#8b7e71"
+            label={{
+              value: `전체 평균 ${totalAvg}`,
+              fontSize: 9,
+              fill: '#766a5e',
+            }}
+          />
+        )}
+        <ReferenceLine
+          y={todayAvg}
+          stroke="#66715d"
+          label={{
+            value: `오늘 평균 ${todayAvg}`,
+            position: 'insideBottomRight',
+            fontSize: 9,
+            fill: '#56624f',
+          }}
+        />
+        <defs>
+          <linearGradient id="productivePacePaper" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#66715d" stopOpacity={0.22} />
+            <stop offset="100%" stopColor="#66715d" stopOpacity={0.02} />
+          </linearGradient>
+        </defs>
         <Area
           type="monotone"
-          dataKey={(o) => o.pace}
+          dataKey="pace"
           unit="min/h"
-          stroke="darkgreen"
-          fill="green"
+          stroke="#56624f"
+          strokeWidth={1.8}
+          fill="url(#productivePacePaper)"
         />
       </AreaChart>
     </ResponsiveContainer>

--- a/apps/web/src/components/dataManagement/DataManagementButton.tsx
+++ b/apps/web/src/components/dataManagement/DataManagementButton.tsx
@@ -110,7 +110,7 @@ export const DataManagementButton = ({ onClick }: Props) => {
     !isAuthenticated && !shouldShowSyncAttemptToast && !shouldShowSuccessToast;
 
   return (
-    <div className="relative">
+    <div className="group relative">
       <button
         type="button"
         className={clsx('btn btn-circle btn-ghost transition-colors', {
@@ -142,7 +142,7 @@ export const DataManagementButton = ({ onClick }: Props) => {
         </div>
       )}
       {shouldShowUnauthenticatedToast && (
-        <div className="animate-in fade-in slide-in-from-top-1 absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 duration-200">
+        <div className="pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 opacity-0 transition-opacity duration-200 group-focus-within:opacity-100 group-hover:opacity-100">
           <div className="relative">
             <div className="whitespace-nowrap rounded-lg border border-error bg-base-100 px-3 py-2 text-xs font-medium text-error shadow-lg">
               동기화가 되고 있지 않습니다.

--- a/apps/web/src/components/days/DayNavigator.tsx
+++ b/apps/web/src/components/days/DayNavigator.tsx
@@ -1,10 +1,10 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useDispatch } from 'react-redux';
 
 import { goToNextDate, goToPrevDate, goToToday } from '../../store/logs';
+import { Button } from '../ui/button';
 
-const PREV_DAY_BUTTON_TEXT = '←';
 const TODAY_BUTTON_TEXT = '오늘';
-const NEXT_DAY_BUTTON_TEXT = '→';
 
 export const DayNavigator = () => {
   const dispatch = useDispatch();
@@ -13,19 +13,33 @@ export const DayNavigator = () => {
   const handleTomorrowButton = () => dispatch(goToNextDate());
 
   return (
-    <div className="flex gap-1">
-      <button className="btn btn-xs sm:btn-sm" onClick={handleYesterdayButton}>
-        <span className="sm:text-lg">{PREV_DAY_BUTTON_TEXT}</span>
-      </button>
-      <button
-        className="btn btn-primary btn-xs sm:btn-sm"
+    <div className="flex items-center rounded-md border border-[#c9baa7] bg-[#f5ecdf]/80 p-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7"
+        onClick={handleYesterdayButton}
+        aria-label="이전 날짜"
+      >
+        <ChevronLeft size={14} />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 min-w-16 font-serif text-sm"
         onClick={handleTodayButton}
       >
-        <span className="sm:text-lg">{TODAY_BUTTON_TEXT}</span>
-      </button>
-      <button className="btn btn-xs sm:btn-sm" onClick={handleTomorrowButton}>
-        <span className="sm:text-lg">{NEXT_DAY_BUTTON_TEXT}</span>
-      </button>
+        {TODAY_BUTTON_TEXT}
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7"
+        onClick={handleTomorrowButton}
+        aria-label="다음 날짜"
+      >
+        <ChevronRight size={14} />
+      </Button>
     </div>
   );
 };

--- a/apps/web/src/components/texts/ProductiveToggle.tsx
+++ b/apps/web/src/components/texts/ProductiveToggle.tsx
@@ -1,35 +1,57 @@
 import clsx from 'clsx';
+import { Minus, Plus } from 'lucide-react';
 import React from 'react';
+
+import { Button } from '../ui/button';
 
 interface ProductiveToggleProps {
   isProductive: boolean;
   setIsProductive: (value: boolean) => void;
-  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-  checkboxRef: React.RefObject<HTMLInputElement | null>;
+  firstButtonRef: React.RefObject<HTMLButtonElement | null>;
 }
 
 export const ProductiveToggle = ({
   isProductive,
   setIsProductive,
-  onKeyDown,
-  checkboxRef,
+  firstButtonRef,
 }: ProductiveToggleProps) => (
-  <label className="relative inline-flex cursor-pointer items-center">
-    <input
-      type="checkbox"
-      className={clsx('toggle toggle-sm', isProductive && 'toggle-success')}
-      checked={isProductive}
-      onChange={(e) => setIsProductive(e.target.checked)}
-      onKeyDown={onKeyDown}
-      ref={checkboxRef}
-    />
-    <span
+  <div
+    role="radiogroup"
+    aria-label="기록 유형"
+    className="inline-flex rounded-md border border-[#c8b9a5] bg-[#eee2d3] p-1"
+  >
+    <Button
+      ref={firstButtonRef}
+      role="radio"
+      aria-checked={isProductive}
+      variant="ghost"
+      size="sm"
       className={clsx(
-        'pointer-events-none absolute flex h-4 w-4 items-center justify-center text-[10px] font-bold text-white transition-all',
-        isProductive ? 'left-3.5' : 'left-0.5',
+        'h-7 gap-1.5 px-2.5 text-[11px]',
+        isProductive
+          ? '!bg-[#66715d] !text-[#fffaf1] shadow-sm'
+          : 'text-[#6d6359]',
       )}
+      onClick={() => setIsProductive(true)}
     >
-      {isProductive ? '+' : '-'}
-    </span>
-  </label>
+      <Plus size={12} /> 생산
+      <span className="ml-0.5 text-[8px] opacity-65">ALT 1</span>
+    </Button>
+    <Button
+      role="radio"
+      aria-checked={!isProductive}
+      variant="ghost"
+      size="sm"
+      className={clsx(
+        'h-7 gap-1.5 px-2.5 text-[11px]',
+        !isProductive
+          ? '!bg-[#a64f38] !text-[#fffaf1] shadow-sm'
+          : 'text-[#6d6359]',
+      )}
+      onClick={() => setIsProductive(false)}
+    >
+      <Minus size={12} /> 소비
+      <span className="ml-0.5 text-[8px] opacity-65">ALT 2</span>
+    </Button>
+  </div>
 );

--- a/apps/web/src/components/texts/TextLogContainer.tsx
+++ b/apps/web/src/components/texts/TextLogContainer.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { ArrowUpRight, Clock3, Minus, Plus } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -27,12 +28,15 @@ import {
   parseTimeInput,
 } from '../../utils/timeUtils';
 import { RestTimeInputDialog } from '../dialogs/RestTimeInputDialog';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 import { ProductiveToggle } from './ProductiveToggle';
 
 const storageListener = new StorageListener();
 
 export const TextLogContainer = () => {
-  const checkboxRef = useRef<HTMLInputElement>(null); // NOTE: +/- 여부를 스페이스바로 쉽게 토글하고, 탭으로 곧장 quick input으로 이동 가능하므로, checkbox에 focus 둠.
+  const modeControlRef = useRef<HTMLButtonElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const timeInputRef = useRef<HTMLInputElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -140,7 +144,7 @@ export const TextLogContainer = () => {
     dispatch(clearRestNotification());
 
     resetInputs();
-    textareaRef.current?.focus();
+    inputRef.current?.focus();
   };
 
   const resetInputs = useCallback(() => {
@@ -179,7 +183,7 @@ export const TextLogContainer = () => {
       // 상태 초기화
       resetInputs();
       setPendingRestLog(null);
-      textareaRef.current?.focus();
+      setTimeout(() => inputRef.current?.focus(), 100);
     },
     [dispatch, pendingRestLog, resetInputs, setRawLogs, timeInput],
   );
@@ -209,16 +213,9 @@ export const TextLogContainer = () => {
     }
   };
 
-  const handleEnterOnCheckbox = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      appendLog();
-    }
-  };
-
   useEffect(() => {
     synchronizeInput();
-    checkboxRef.current?.focus();
+    inputRef.current?.focus();
   }, [synchronizeInput]);
 
   // handleDateChange를 하지 말고, 여기서 return을 해서 cleanup을 하도록 하면 prevDate 만들 필요 없음.
@@ -228,7 +225,7 @@ export const TextLogContainer = () => {
       const localData = loadFromStorage(currentDate);
       dispatch(hydrateRawLog(localData.content));
     });
-    checkboxRef.current?.focus();
+    inputRef.current?.focus();
   }, [currentDate, dispatch]);
 
   const handleQuickAppend = useCallback(
@@ -249,7 +246,7 @@ export const TextLogContainer = () => {
       resetInputs();
       // 커맨드 팔레트가 닫힌 후 포커스 이동
       setTimeout(() => {
-        textareaRef.current?.focus();
+        inputRef.current?.focus();
       }, 100);
     },
     [currentTimeConsideringMaxTime, dispatch, resetInputs, setRawLogs],
@@ -274,75 +271,161 @@ export const TextLogContainer = () => {
     };
   }, [handleQuickAppend]);
 
+  useEffect(() => {
+    const handleKeyboardShortcut = (event: KeyboardEvent) => {
+      const target = event.target;
+      const isEditing =
+        target instanceof HTMLElement &&
+        (target.isContentEditable ||
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName));
+      const isCommandPaletteTarget =
+        target instanceof Element &&
+        target.closest('.editorial-command-palette') !== null;
+
+      if (
+        isRestDialogOpen ||
+        isCommandPaletteTarget ||
+        event.metaKey ||
+        event.ctrlKey
+      ) {
+        return;
+      }
+
+      if (event.altKey && event.code === 'Digit1') {
+        event.preventDefault();
+        setIsProductive(true);
+        inputRef.current?.focus();
+        return;
+      }
+
+      if (event.altKey && event.code === 'Digit2') {
+        event.preventDefault();
+        setIsProductive(false);
+        inputRef.current?.focus();
+        return;
+      }
+
+      if (!isEditing && !event.altKey && event.key === '/') {
+        event.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyboardShortcut);
+    return () => window.removeEventListener('keydown', handleKeyboardShortcut);
+  }, [isRestDialogOpen]);
+
+  const recordedLineCount = rawLogs
+    .split('\n')
+    .filter((line) => line.trim().length > 0).length;
+
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center gap-2">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-4 flex items-end justify-between gap-5">
+        <div>
+          <div className="flex items-center gap-2">
+            <p className="font-serif text-xl tracking-[-0.025em] text-[#322a24]">
+              무엇에 시간을 썼나요?
+            </p>
+            <Badge variant="outline">{recordedLineCount} lines</Badge>
+          </div>
+          <p className="mt-1 text-xs leading-relaxed text-[#776b5f]">
+            시각과 한 문장을 남기면 아래 원문과 분석이 함께 갱신됩니다.
+          </p>
+        </div>
         <ProductiveToggle
           isProductive={isProductive}
           setIsProductive={setIsProductive}
-          onKeyDown={handleEnterOnCheckbox}
-          checkboxRef={checkboxRef}
+          firstButtonRef={modeControlRef}
         />
-        <input
-          ref={timeInputRef}
-          type="text"
-          className={clsx(
-            'input input-bordered w-20 text-xs',
-            isTimeInputShaking ? 'shake-animation' : '',
-          )}
-          placeholder={currentTimeConsideringMaxTime}
-          value={timeInput}
-          onChange={handleTimeInputChange}
-          onKeyDown={handleEnterOnTextInput}
-        />
-        <input
-          ref={inputRef}
-          type="text"
-          className={clsx(
-            'input input-bordered flex-1 text-xs',
-            isQuickInputShaking ? 'shake-animation' : '',
-          )}
-          placeholder="Enter 키를 눌러 활동 내역 추가"
-          value={quickInput}
-          onChange={handleQuickInputChange}
-          onKeyDown={handleEnterOnTextInput}
-        />
-        <button
-          type="button"
-          className="btn btn-primary btn-sm"
-          onClick={appendLog}
-        >
-          추가
-        </button>
+      </div>
 
-        {/* 간단 입력 영역 */}
-        <div className="flex items-center gap-1 border-l border-base-300 pl-2">
-          <span className="text-xs text-base-content/60">간단 입력</span>
-          <button
-            type="button"
-            className="btn btn-success btn-outline btn-xs"
+      <div className="journal-capture-bar grid grid-cols-[92px_minmax(0,1fr)_auto] items-end gap-3 border-y border-[#a64f38]/35 bg-[#f5eadc]/70 px-4 py-4 shadow-[inset_3px_0_0_#a64f38]">
+        <label className="block">
+          <span className="mb-1.5 flex items-center gap-1 text-[9px] font-bold uppercase tracking-[0.18em] text-[#7d6f62]">
+            <Clock3 size={11} /> 시각
+          </span>
+          <Input
+            ref={timeInputRef}
+            className={clsx(
+              'font-mono text-xs tabular-nums',
+              isTimeInputShaking && 'shake-animation',
+            )}
+            placeholder={currentTimeConsideringMaxTime}
+            value={timeInput}
+            onChange={handleTimeInputChange}
+            onKeyDown={handleEnterOnTextInput}
+            aria-label="기록 시각"
+          />
+        </label>
+
+        <label className="block min-w-0">
+          <span className="mb-1.5 block text-[9px] font-bold uppercase tracking-[0.18em] text-[#7d6f62]">
+            한 문장 기록
+          </span>
+          <Input
+            ref={inputRef}
+            className={clsx(
+              'font-serif text-[15px]',
+              isQuickInputShaking && 'shake-animation',
+            )}
+            placeholder="예: 회의록을 정리하고 다음 작업을 골랐다"
+            value={quickInput}
+            onChange={handleQuickInputChange}
+            onKeyDown={handleEnterOnTextInput}
+            aria-label="활동 내용"
+          />
+        </label>
+
+        <Button className="h-10 px-5" onClick={appendLog}>
+          기록
+          <ArrowUpRight size={14} />
+        </Button>
+      </div>
+
+      <div className="flex items-center justify-between gap-4 border-b border-[#d4c7b7] px-1 py-3">
+        <div className="flex items-center gap-1.5">
+          <span className="mr-1 text-[9px] font-bold uppercase tracking-[0.16em] text-[#8b7e70]">
+            빠른 시작
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-[#52604c]"
             onClick={() => handleQuickAppend(true, '생산')}
-            title="생산 기록 추가"
+            title="생산 기록을 현재 시각으로 바로 추가"
           >
-            +
-          </button>
-          <button
-            type="button"
-            className="btn btn-warning btn-outline btn-xs"
+            <Plus size={12} /> 생산
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-[#9a4a36]"
             onClick={() => handleQuickAppend(false, '소비')}
-            title="소비 기록 추가"
+            title="소비 기록을 현재 시각으로 바로 추가"
           >
-            −
-          </button>
+            <Minus size={12} /> 소비
+          </Button>
         </div>
+        <p className="text-[10px] text-[#8b7e70]">
+          <kbd className="editorial-kbd">Enter</kbd> 저장 ·{' '}
+          <kbd className="editorial-kbd">/</kbd> 입력 포커스
+        </p>
       </div>
 
       <textarea
-        className="textarea textarea-bordered textarea-lg mb-2 aspect-square flex-1 text-xs"
+        className="journal-raw-log mt-5 min-h-[380px] flex-1 resize-none rounded-sm border border-[#c9baa7] px-6 py-5 font-mono text-[12px] leading-8 text-[#433a33] outline-none transition focus:border-[#a64f38]/70 focus:ring-2 focus:ring-[#a64f38]/10"
         value={rawLogs}
         ref={textareaRef}
         onChange={handleChange}
+        aria-label="하루 원문 기록"
+        spellCheck={false}
       />
+
+      <div className="mt-2 flex items-center justify-between text-[9px] font-semibold uppercase tracking-[0.15em] text-[#9a8d7f]">
+        <span>Raw journal · 직접 수정 가능</span>
+        <span>{currentDate}</span>
+      </div>
 
       <RestTimeInputDialog
         isOpen={isRestDialogOpen}

--- a/apps/web/src/components/texts/TimeSummary.tsx
+++ b/apps/web/src/components/texts/TimeSummary.tsx
@@ -23,31 +23,36 @@ export const TimeSummary = ({ logs }: TimeSummaryProps) => {
 
   const isProductiveSurplus = difference >= 0;
   const label = isProductiveSurplus ? '확보 시간' : '초과 시간';
-  const colorClass = isProductiveSurplus ? 'text-green-600' : 'text-red-600';
+  const colorClass = isProductiveSurplus ? 'text-[#56624f]' : 'text-[#a64f38]';
 
   return (
-    <div className="flex gap-1 text-lg">
-      <span>
-        {label}: [
-        <span className={`font-bold ${colorClass}`}>
+    <div className="grid grid-cols-[1.25fr_1fr_1fr] gap-3 border-y border-[#d5c8b7] py-3">
+      <div>
+        <p className="text-[9px] font-bold uppercase tracking-[0.16em] text-[#8c7f71]">
+          오늘의 {label}
+        </p>
+        <p
+          className={`mt-1 font-serif text-[28px] leading-none tracking-[-0.04em] ${colorClass}`}
+        >
           {minutesToTimeString(Math.abs(difference))}
-        </span>
-        ]
-      </span>
-      <span>
-        생산{' '}
-        <span className="font-bold text-green-600">
+        </p>
+      </div>
+      <div className="border-l border-[#d5c8b7] pl-3">
+        <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[#75806d]">
+          생산 · {productiveRatio}%
+        </p>
+        <p className="mt-1 font-serif text-lg text-[#424b3d]">
           {minutesToTimeString(productive)}
-        </span>{' '}
-        ({productiveRatio}%)
-      </span>
-      <span>
-        소비{' '}
-        <span className="font-bold text-red-600">
+        </p>
+      </div>
+      <div className="border-l border-[#d5c8b7] pl-3">
+        <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[#a65c49]">
+          소비 · {wastedRatio}%
+        </p>
+        <p className="mt-1 font-serif text-lg text-[#804331]">
           {minutesToTimeString(wasted)}
-        </span>{' '}
-        ({wastedRatio}%)
-      </span>
+        </p>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,30 @@
+import clsx from 'clsx';
+import * as React from 'react';
+
+type BadgeVariant = 'default' | 'outline' | 'olive' | 'terracotta';
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default: 'border-transparent bg-[#342c26] text-[#fffaf1]',
+  outline: 'border-[#c7b8a5] bg-transparent text-[#665b50]',
+  olive: 'border-[#738069]/25 bg-[#738069]/10 text-[#4d5947]',
+  terracotta: 'border-[#a64f38]/25 bg-[#a64f38]/10 text-[#8f412e]',
+};
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+export const Badge = ({
+  className,
+  variant = 'default',
+  ...props
+}: BadgeProps) => (
+  <span
+    className={clsx(
+      'inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]',
+      variantClasses[variant],
+      className,
+    )}
+    {...props}
+  />
+);

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import clsx from 'clsx';
+import * as React from 'react';
+
+type ButtonVariant = 'default' | 'outline' | 'ghost' | 'muted';
+type ButtonSize = 'default' | 'sm' | 'icon';
+
+const variantClasses: Record<ButtonVariant, string> = {
+  default:
+    'bg-[#a64f38] text-[#fffaf1] shadow-[0_1px_0_rgba(69,42,32,0.2)] hover:bg-[#8f412e]',
+  outline:
+    'border border-[#cbbdab] bg-[#fffaf1]/70 text-[#332a24] hover:border-[#a64f38] hover:bg-[#f5eadc]',
+  ghost: 'text-[#665b50] hover:bg-[#ede1d1] hover:text-[#2c241f]',
+  muted: 'bg-[#e9ddcc] text-[#4d4238] hover:bg-[#ded0bd]',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-8 px-3 text-xs',
+  icon: 'h-9 w-9',
+};
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      type = 'button',
+      variant = 'default',
+      size = 'default',
+      ...props
+    },
+    ref,
+  ) => (
+    <button
+      ref={ref}
+      type={type}
+      className={clsx(
+        'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#a64f38]/40 disabled:pointer-events-none disabled:opacity-50',
+        variantClasses[variant],
+        sizeClasses[size],
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+Button.displayName = 'Button';

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,25 @@
+import clsx from 'clsx';
+import * as React from 'react';
+
+export const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={clsx(
+      'rounded-lg border border-[#cfc1ae] bg-[#fbf4e8] text-[#2e2823] shadow-[0_18px_45px_rgba(76,55,38,0.08)]',
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = 'Card';
+
+export const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={clsx('p-5', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import clsx from 'clsx';
+import * as React from 'react';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
+  type?: React.HTMLInputTypeAttribute;
+}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => (
+    <input
+      ref={ref}
+      type={type}
+      className={clsx(
+        'flex h-10 w-full rounded-md border border-[#cbbdab] bg-[#fffaf1]/75 px-3 text-sm text-[#2f2924] outline-none transition placeholder:text-[#948577] focus:border-[#a64f38] focus:ring-2 focus:ring-[#a64f38]/10 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+Input.displayName = 'Input';

--- a/apps/web/src/features/AvailableRestTimeChartArea.tsx
+++ b/apps/web/src/features/AvailableRestTimeChartArea.tsx
@@ -1,5 +1,6 @@
 import { AvailableRestTimeChart } from '../components/charts/AvailableRestTimeChart';
 import { TimeSummary } from '../components/texts/TimeSummary';
+import { Card, CardContent } from '../components/ui/card';
 import { Log } from '../utils/PaceUtil';
 
 /**
@@ -10,11 +11,29 @@ export const Area_AvailableRestTimeChart = ({
 }: {
   logsForCharts: Log[];
 }) => (
-  <div className="flex flex-col gap-2">
-    <div className="h-10">
-      <h1 className="text-sm font-bold">[초과 휴식 시간]</h1>
+  <Card className="editorial-analysis-card rounded-[3px] bg-[#f8efe2]/90">
+    <CardContent className="p-4 xl:p-5">
+      <div className="mb-3 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-[9px] font-bold uppercase tracking-[0.2em] text-[#a64f38]">
+            Figure 01
+          </p>
+          <h3 className="mt-1 font-serif text-xl tracking-[-0.025em]">
+            회복 여력의 흐름
+          </h3>
+        </div>
+        <p className="max-w-36 text-right text-[10px] leading-relaxed text-[#807468]">
+          생산으로 확보한 시간과 소비로 사용한 시간의 균형
+        </p>
+      </div>
       <TimeSummary logs={logsForCharts} />
-    </div>
-    <AvailableRestTimeChart logs={logsForCharts} />
-  </div>
+      <div className="mt-2 h-[205px]">
+        <AvailableRestTimeChart logs={logsForCharts} />
+      </div>
+      <p className="mt-1 border-t border-[#d9cdbd] pt-2 text-[9px] leading-relaxed text-[#8b7e71]">
+        0선 아래는 쉴 수 있는 시간이 남아 있음을, 위는 소비 시간이 앞섰음을
+        뜻합니다.
+      </p>
+    </CardContent>
+  </Card>
 );

--- a/apps/web/src/features/ProductivePaceChartArea.tsx
+++ b/apps/web/src/features/ProductivePaceChartArea.tsx
@@ -2,6 +2,8 @@ import { ChangeEvent, useState } from 'react';
 
 import { DayRatioBar } from '../components/charts/DayRatioBar';
 import { ProductivePaceChart } from '../components/charts/ProductivePaceChart';
+import { Card, CardContent } from '../components/ui/card';
+import { Input } from '../components/ui/input';
 import { DEFAULT_PACE_IN_MIN } from '../policies/userConfig';
 import { avgPaceOf, Log } from '../utils/PaceUtil';
 import { loadFromStorage, saveToStorage } from '../utils/StorageUtil';
@@ -28,25 +30,49 @@ export const Area_ProductivePaceChart = ({
   };
 
   return (
-    <div className="flex flex-col gap-2">
-      <div>
-        <h1 className="text-sm font-bold">[생산 페이스]</h1>
+    <Card className="editorial-analysis-card rounded-[3px] bg-[#f8efe2]/90">
+      <CardContent className="p-4 xl:p-5">
+        <div className="mb-3 flex items-start justify-between gap-4">
+          <div>
+            <p className="text-[9px] font-bold uppercase tracking-[0.2em] text-[#66715d]">
+              Figure 02
+            </p>
+            <h3 className="mt-1 whitespace-nowrap font-serif text-xl tracking-[-0.025em]">
+              몰입의 밀도
+            </h3>
+          </div>
+          <label className="flex items-center gap-2 text-[9px] font-bold uppercase tracking-[0.12em] text-[#807468]">
+            목표
+            <Input
+              className="h-7 w-14 px-2 text-center font-mono text-[11px]"
+              value={targetPace}
+              onChange={updateTargetPace}
+              inputMode="numeric"
+              aria-label="목표 생산 페이스"
+            />
+          </label>
+        </div>
+
         <DayRatioBar logs={logsForCharts} />
-        <div className="mt-1 flex items-center gap-2">
-          <span className="text-xs">목표 페이스 설정: </span>
-          <input
-            className="input input-bordered input-xs"
-            value={targetPace}
-            onChange={updateTargetPace}
+        <div className="mt-2 flex items-center justify-between text-[9px] font-semibold uppercase tracking-[0.12em] text-[#8b7e71]">
+          <span>생산</span>
+          <span>하루의 방향 분포</span>
+          <span>소비</span>
+        </div>
+
+        <div className="mt-1 h-[190px]">
+          <ProductivePaceChart
+            data={logsForCharts}
+            totalAvg={0}
+            targetPace={targetPace}
+            todayAvg={logsForCharts.length ? avgPaceOf(logsForCharts) : 0}
           />
         </div>
-      </div>
-      <ProductivePaceChart
-        data={logsForCharts}
-        totalAvg={0}
-        targetPace={targetPace}
-        todayAvg={avgPaceOf(logsForCharts)}
-      />
-    </div>
+        <p className="mt-1 border-t border-[#d9cdbd] pt-2 text-[9px] leading-relaxed text-[#8b7e71]">
+          선이 높을수록 한 시간 안에 확보한 생산 시간이 많습니다. 목표선은 직접
+          조정할 수 있습니다.
+        </p>
+      </CardContent>
+    </Card>
   );
 };

--- a/apps/web/src/pages/LogWriterPage.tsx
+++ b/apps/web/src/pages/LogWriterPage.tsx
@@ -1,4 +1,4 @@
-import { Bell, Timer } from 'lucide-react';
+import { Bell, BookOpenText, Timer } from 'lucide-react';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -7,6 +7,8 @@ import { ConflictDialog } from '../components/common/ConflictDialog';
 import { DataManagementButton } from '../components/dataManagement/DataManagementButton';
 import { DayNavigator } from '../components/days/DayNavigator';
 import { TextLogContainer } from '../components/texts/TextLogContainer';
+import { Badge } from '../components/ui/badge';
+import { Button } from '../components/ui/button';
 import { Area_AvailableRestTimeChart } from '../features/AvailableRestTimeChartArea';
 import { Area_ProductivePaceChart } from '../features/ProductivePaceChartArea';
 import {
@@ -56,42 +58,100 @@ export const LogWriterPage = () => {
   const { remainingTime, isOvertime } = useRemainingTime(currentNotification);
 
   return (
-    <div className="mx-auto flex h-screen min-w-[400px] max-w-screen-xl flex-col p-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <h1 className="text-xs font-bold sm:text-sm">
-            [기록지] ({currentDate})
-          </h1>
-          {currentNotification && (
-            <div
-              className={`badge badge-lg gap-2 ${isOvertime ? 'badge-error animate-pulse' : 'badge-success'}`}
-            >
-              <Timer size={16} />
-              잔여 휴식 시간: {remainingTime}
+    <div className="editorial-shell min-h-screen text-[#302923]">
+      <div className="mx-auto flex min-h-screen max-w-[1680px] flex-col px-5 pb-6 pt-4 xl:px-8">
+        <header className="editorial-topbar min-h-16 flex items-center justify-between gap-5 border-b border-[#aa9b88]/60 px-1 pb-4">
+          <div className="flex min-w-fit items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full border border-[#a64f38]/35 bg-[#fbf4e8] text-[#a64f38] shadow-sm">
+              <BookOpenText size={19} strokeWidth={1.6} />
             </div>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          <DayNavigator />
-          <button
-            type="button"
-            className="btn btn-circle btn-ghost"
-            onClick={() => setIsSoundSettingsOpen(true)}
-            title="알림음 설정"
-          >
-            <Bell size={16} />
-          </button>
+            <div>
+              <p className="font-serif text-lg leading-none tracking-[-0.02em]">
+                My Commit
+              </p>
+              <p className="mt-1 text-[9px] font-semibold uppercase tracking-[0.24em] text-[#776b5f]">
+                Daily work journal
+              </p>
+            </div>
+          </div>
 
-          <DataManagementButton onClick={() => setIsDataManagementOpen(true)} />
-          <ThemeSelector />
-          <AuthHeader />
-        </div>
-      </div>
-      <div className="my-0 grid min-h-0 flex-1 grid-cols-1 grid-rows-4 p-4 sm:grid-cols-2 sm:grid-rows-2">
-        <TextLogContainer />
-        <div>hello</div>
-        <Area_AvailableRestTimeChart logsForCharts={logsForCharts} />
-        <Area_ProductivePaceChart logsForCharts={logsForCharts} />
+          <div className="flex items-center gap-3">
+            <DayNavigator />
+          </div>
+
+          <div className="editorial-actions flex min-w-fit items-center gap-1.5">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setIsSoundSettingsOpen(true)}
+              title="알림음 설정"
+              aria-label="알림음 설정"
+            >
+              <Bell size={16} />
+            </Button>
+            <DataManagementButton
+              onClick={() => setIsDataManagementOpen(true)}
+            />
+            <ThemeSelector />
+            <AuthHeader />
+          </div>
+        </header>
+
+        <main className="grid flex-1 gap-5 pt-5 lg:grid-cols-[minmax(0,1.6fr)_minmax(360px,0.82fr)] xl:gap-7">
+          <section className="journal-page relative flex min-h-[760px] min-w-0 flex-col overflow-hidden rounded-[3px] border border-[#c8b9a5] bg-[#fbf4e8] px-7 py-7 shadow-[0_24px_80px_rgba(78,58,40,0.13)] xl:px-10 xl:py-9">
+            <div className="relative z-10 mb-7 flex items-end justify-between gap-5 border-b border-[#bfb09c]/70 pb-6">
+              <div>
+                <Badge variant="terracotta">Entry · {currentDate}</Badge>
+                <h1 className="mt-4 font-serif text-[clamp(2.4rem,4vw,4.8rem)] leading-[0.86] tracking-[-0.055em] text-[#29211d]">
+                  오늘의 기록.
+                </h1>
+              </div>
+              <div className="max-w-48 pb-1 text-right">
+                <p className="font-serif text-sm italic leading-relaxed text-[#6e6257]">
+                  쌓인 시간은 숫자가 되고,
+                  <br />쓴 문장은 하루가 됩니다.
+                </p>
+              </div>
+            </div>
+
+            <div className="relative z-10 flex min-h-0 flex-1 flex-col">
+              <TextLogContainer />
+            </div>
+          </section>
+
+          <aside className="flex min-w-0 flex-col gap-4 pb-4">
+            <div className="flex items-end justify-between border-b border-[#aa9b88]/60 px-1 pb-4">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-[0.26em] text-[#a64f38]">
+                  Marginalia
+                </p>
+                <h2 className="mt-1 font-serif text-2xl tracking-[-0.025em]">
+                  흐름을 읽는 여백
+                </h2>
+              </div>
+              {currentNotification ? (
+                <Badge
+                  variant={isOvertime ? 'terracotta' : 'olive'}
+                  className={isOvertime ? 'animate-pulse' : ''}
+                >
+                  <Timer size={11} />
+                  {isOvertime ? '휴식 초과' : `휴식 ${remainingTime}`}
+                </Badge>
+              ) : (
+                <Badge variant="outline">휴식 알림 대기</Badge>
+              )}
+            </div>
+
+            <Area_AvailableRestTimeChart logsForCharts={logsForCharts} />
+            <Area_ProductivePaceChart logsForCharts={logsForCharts} />
+
+            <div className="editorial-shortcuts mt-auto grid grid-cols-3 gap-px overflow-hidden rounded-md border border-[#c9baa7] bg-[#c9baa7] text-[#5f544a]">
+              <ShortcutHint keys="/" label="입력으로" />
+              <ShortcutHint keys="Alt 1 · 2" label="생산 · 소비" />
+              <ShortcutHint keys="⌘ / Ctrl P" label="명령 팔레트" />
+            </div>
+          </aside>
+        </main>
       </div>
 
       <SoundSettingsDialog
@@ -102,7 +162,7 @@ export const LogWriterPage = () => {
         <Suspense
           fallback={
             <div className="modal modal-open modal-bottom sm:modal-middle">
-              <div className="modal-box flex h-40 w-full max-w-2xl items-center justify-center">
+              <div className="modal-box flex h-40 w-full max-w-2xl items-center justify-center bg-[#fbf4e8]">
                 <span className="loading loading-spinner loading-md" />
               </div>
             </div>
@@ -118,3 +178,14 @@ export const LogWriterPage = () => {
     </div>
   );
 };
+
+const ShortcutHint = ({ keys, label }: { keys: string; label: string }) => (
+  <div className="bg-[#f5ecdf] px-3 py-3 text-center">
+    <kbd className="font-serif text-xs font-semibold text-[#3c332c]">
+      {keys}
+    </kbd>
+    <p className="mt-1 text-[9px] font-semibold uppercase tracking-[0.11em]">
+      {label}
+    </p>
+  </div>
+);


### PR DESCRIPTION
## 작업 목표

### 작업 배경

- 시간 기록 화면의 입력 편의성, 차트 가독성, 데스크톱 UI 방향을 비교하는 5개 시안 중 기록 저널 중심 안

### 기대 효과

- 원문 기록을 장부처럼 읽고 편집 가능
- 생산/소비 입력과 분석 정보의 시각적 위계 개선
- 장시간 사용 시 화면 밀도와 시각 피로 감소

### 달성 방법

- 기록 맥락을 보존하는 경험 검증을 위해 편집 지면과 분석 각주 구조로 화면 재구성

## 변경 사항

- [x] ivory paper, ink, terracotta 기반 Editorial Journal 레이아웃 추가
  - 좌측 기록지, 우측 marginalia와 차트 구성
- [x] 생산/소비 segmented control과 문장형 capture bar 추가
- [x] 입력 단축키 안내와 줄노트형 raw log editor 추가
- [x] 차트 빈 상태, 축, tooltip, 요약 정보 개선
- [x] TailwindCSS 기반 shadcn-style UI component 추가
